### PR TITLE
Return bool instead of String in isTorchAvailable function

### DIFF
--- a/ios/Classes/ScanditFlutterDataCaptureCore.swift
+++ b/ios/Classes/ScanditFlutterDataCaptureCore.swift
@@ -192,7 +192,7 @@ public class ScanditFlutterDataCaptureCore: NSObject, FlutterPlatformViewFactory
         SDCCameraPositionFromJSONString(positionString, &position)
         let camera = Camera(position: position)
         let isTorchAvailable = camera?.isTorchAvailable ?? false
-        reply("\(isTorchAvailable)")
+        reply(isTorchAvailable)
     }
 
     func emitFeedback(_ feedbackJSON: String, reply: FlutterResult) {


### PR DESCRIPTION
Addresses this crash while using 6.9.0
```
flutter: type 'String' is not a subtype of type 'bool?' in type cast
flutter:
#0      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:158:41)
<asynchronous suspension>
#1      _CameraController.isTorchAvailable (package:scandit_flutter_datacapture_core/src/camera.dart:340:9)
<asynchronous suspension>
```